### PR TITLE
Change the top level key name from "skillManifest" to "manifest" in skill.json

### DIFF
--- a/skill.json
+++ b/skill.json
@@ -1,5 +1,5 @@
 {
-    "skillManifest": {
+    "manifest": {
       "publishingInformation": {
         "locales": {
           "en-US": {


### PR DESCRIPTION
Change the key name from "skillManifest" (v0 value) to "manifest" according to the v1 version of manifest: https://developer.amazon.com/docs/smapi/skill-manifest.html#manifest


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
